### PR TITLE
feat(hmac): add public static HMACSignature.generateSignature(...) fo…

### DIFF
--- a/src/main/java/org/maviance/s3pjavaclient/HMACSignature.java
+++ b/src/main/java/org/maviance/s3pjavaclient/HMACSignature.java
@@ -36,6 +36,15 @@ public class HMACSignature {
     }
 
     /**
+     * Generate HMAC-SHA1 signature for an HTTP request.
+     * Intended for Kotlin/Java interop and one-off use.
+     */
+    public static String generateSignature(String method, String url, List<Pair> params, String accessSecret) {
+        HMACSignature signature = new HMACSignature(method, url, params);
+        return signature.generate(accessSecret);
+    }
+
+    /**
      * This method generates the signature based on given parameters.
      *
      * @param accessSecret  access secret used to encrypt the information


### PR DESCRIPTION
# Why

ApiClient.buildAuthorizationHeader(...) is private and HMACSignature ctor is package-private.

Kotlin and external modules can now compute signatures directly using a stable, supported API.

# Notes

No change to signing algorithm or behavior.

Method is stateless and thread-safe.

Works with existing helpers like HMACSignature.buildSignatureData(...).